### PR TITLE
タスク表示/非表示切り替え機能の実装

### DIFF
--- a/todolist/src/App.tsx
+++ b/todolist/src/App.tsx
@@ -3,7 +3,7 @@ import TaskInputForm from './TaskInputForm';
 import Radiobutton from './RadioButton';
 import TaskTable from './TaskTable';
 import Title from './Title';
-import { Task, TaskStatus } from './types';
+import { Task, TaskStatus, TaskFilterStatus } from './types';
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -37,12 +37,25 @@ function App() {
     );
   };
 
+  const [selectedStatus, setSelectedStatus] =
+    React.useState<TaskFilterStatus>('all');
+
+  const handleChange = (status: TaskFilterStatus) => {
+    setSelectedStatus(status);
+  };
+
   return (
     <div className="App">
       <Title />
-      <Radiobutton />
+      <Radiobutton onChange={handleChange} selectedStatus={selectedStatus} />
       <TaskTable
-        tasks={tasks}
+        tasks={tasks.filter((task) =>
+          selectedStatus === 'all'
+            ? true
+            : selectedStatus === 'working'
+            ? task.status === '作業中'
+            : task.status === '完了'
+        )}
         onTaskDelete={deleteTask}
         onStatusChange={changeStatus}
       />

--- a/todolist/src/RadioButton.tsx
+++ b/todolist/src/RadioButton.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { TaskFilterStatus } from './types';
 
-function RadioButton() {
-  const [selectedStatus, setSelectedStatus] = React.useState<string>('all');
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedStatus(e.target.value);
-  };
+type RadioButtonProps = {
+  selectedStatus: TaskFilterStatus;
+  onChange: (status: TaskFilterStatus) => void;
+};
+
+function RadioButton({ selectedStatus, onChange }: RadioButtonProps) {
   return (
     <div>
       <label>
@@ -12,7 +14,7 @@ function RadioButton() {
           type="radio"
           value="all"
           checked={selectedStatus === 'all'}
-          onChange={handleChange}
+          onChange={() => onChange('all')}
         />
         すべて
       </label>
@@ -21,7 +23,7 @@ function RadioButton() {
           type="radio"
           value="done"
           checked={selectedStatus === 'done'}
-          onChange={handleChange}
+          onChange={() => onChange('done')}
         />
         完了
       </label>
@@ -30,7 +32,7 @@ function RadioButton() {
           type="radio"
           value="working"
           checked={selectedStatus === 'working'}
-          onChange={handleChange}
+          onChange={() => onChange('working')}
         />
         作業中
       </label>

--- a/todolist/src/types.ts
+++ b/todolist/src/types.ts
@@ -1,5 +1,7 @@
 export type TaskStatus = '作業中' | '完了';
 
+export type TaskFilterStatus = 'all' | 'working' | 'done';
+
 export type Task = {
   id: number;
   text: string;


### PR DESCRIPTION
## 対応
課題①-4タスク表示/非表示切り替え機能の実装と要件の定義が
完了しましたので、レビューをお願い致します。

【要件】
- タスクの状態によって表示/非表示を切り替えできる
- 選択されたラジオボタンに応じて、タスクの表示を切り替える

## 実装内容
- [https://github.com/NaO3430/react-lesson1/pull/4] 

## 出力画面

https://github.com/NaO3430/react-lesson1/assets/127587578/e6539cb1-c290-487e-857b-e7793edac7f6

##参考にした記事
条件式が複数ある三項演算子に混乱した話
https://qiita.com/riekure/items/e510dba2e507403d990a
JavaScriptのラジオボタンでイベントを作成する～実用的なサイトの作り方～
https://webukatu.com/wordpress/blog/25529/
React ラジオボタンを正しく実装する
https://qiita.com/buto/items/9f25b765bbb650d28730